### PR TITLE
feat: expose json parser

### DIFF
--- a/BugSplatDotNetStandard/BugSplatDotNetStandard.csproj
+++ b/BugSplatDotNetStandard/BugSplatDotNetStandard.csproj
@@ -9,8 +9,8 @@
     <Copyright>Copyright BugSplat, All Rights Reserved</Copyright>
     <PackageProjectUrl>https://www.bugsplat.com</PackageProjectUrl>
     <PackageTags>bugsplat crash reporting reporter unhandled exception error catch analytics debug debugging debugger stack trace line numbers net uwp core mono unity xamarin maui</PackageTags>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <FileVersion>4.0.1.0</FileVersion>
     <PackageIconUrl></PackageIconUrl>
     <RepositoryUrl>https://github.com/BugSplat-Git/bugsplat-dotnet-standard</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/BugSplatDotNetStandard/Http/JsonObject.cs
+++ b/BugSplatDotNetStandard/Http/JsonObject.cs
@@ -11,16 +11,16 @@ namespace BugSplatDotNetStandard.Http
     // More information about Unity's plans to update to .NET 6 can be found here:
     // https://forum.unity.com/threads/unity-future-net-development-status.1092205/
 
-    internal class JsonObject
+    public class JsonObject
     {
         private string json;
 
-        internal JsonObject(string json)
+        public JsonObject(string json)
         {
             this.json = json;
         }
                 
-        internal string GetValue(params string[] path)
+        public string GetValue(params string[] path)
         {
             var jsonBytes = Encoding.UTF8.GetBytes(json);
             var quotas = new XmlDictionaryReaderQuotas();


### PR DESCRIPTION
### Description

Expose our dependency-free Json parser so we can remove Newtonsoft in BugSplatCrashHandler.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
