### PR TITLE
feat: attachments from FormDataParams

### DIFF
--- a/BugSplatDotNetStandard/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard/Api/CrashPostClient.cs
@@ -46,8 +46,14 @@ namespace BugSplatDotNetStandard.Api
             var files = overridePostOptions.Attachments
                 .Select(attachment => InMemoryFile.FromFileInfo(attachment))
                 .ToList();
+            
+            var additionalFormDataFiles = overridePostOptions.FormDataParams
+                .Where(file => !string.IsNullOrEmpty(file.FileName) && file.Content != null)
+                .Select(file => new InMemoryFile() { FileName = file.FileName, Content = file.Content.ReadAsByteArrayAsync().Result })
+                .ToList();
 
             files.Add(new InMemoryFile() { FileName = "Callstack.txt", Content = Encoding.UTF8.GetBytes(stackTrace) });
+            files.AddRange(additionalFormDataFiles);
 
             var zipBytes = ZipUtils.CreateInMemoryZipFile(files);
             using (


### PR DESCRIPTION
### Description

Unity was relying on AdditionalFormDataParams to attach a file that only exists in memory. This broke at some point. This change fixes the regression.

### Checklist

- [ ] Tested manually
- [ ] Unit tests pass with no errors or warnings
- [ ] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
