### PR TITLE
fix: handle locked attachments

### DIFF
--- a/BugSplatDotNetStandard.Test/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard.Test/Api/CrashPostClient.cs
@@ -34,7 +34,7 @@ namespace Tests
             lockedFileWriter = File.Open(lockedFile.FullName, FileMode.Create, FileAccess.Write, FileShare.None);
             lockedFileWriter.Write(bytesToWrite, 0, bytesToWrite.Length);
             lockedFileWriter.Flush();
-            var minidumpFile = new FileInfo("minidump.dmp");
+            minidumpFile = new FileInfo("minidump.dmp");
             File.Create(minidumpFile.FullName).Close();
         }
 

--- a/BugSplatDotNetStandard.Test/BugSplatDotNetStandard.Test.csproj
+++ b/BugSplatDotNetStandard.Test/BugSplatDotNetStandard.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/BugSplatDotNetStandard/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard/Api/CrashPostClient.cs
@@ -43,10 +43,11 @@ namespace BugSplatDotNetStandard.Api
         {
             overridePostOptions = overridePostOptions ?? new ExceptionPostOptions();
 
+            var files = CombineListsWithDuplicatesRemoved(defaultPostOptions.Attachments, overridePostOptions.Attachments)
                 .Select(attachment => TryCreateInMemoryFileFromFileInfo(attachment))
                 .Where(file => file != null)
                 .ToList();
-            
+
             var additionalFormDataFiles = overridePostOptions.FormDataParams
                 .Where(file => !string.IsNullOrEmpty(file.FileName) && file.Content != null)
                 .Select(file => new InMemoryFile() { FileName = file.FileName, Content = file.Content.ReadAsByteArrayAsync().Result })
@@ -82,9 +83,7 @@ namespace BugSplatDotNetStandard.Api
                         version,
                         md5,
                         s3Key,
-                        crashTypeId,
-                        defaultPostOptions,
-                        overridePostOptions
+                        crashTypeId
                     );
 
                     ThrowIfHttpRequestFailed(commitS3CrashResponse);
@@ -143,6 +142,7 @@ namespace BugSplatDotNetStandard.Api
         {
             overridePostOptions = overridePostOptions ?? new MinidumpPostOptions();
 
+            var files = CombineListsWithDuplicatesRemoved(defaultPostOptions.Attachments, overridePostOptions.Attachments)
                 .Select(attachment => TryCreateInMemoryFileFromFileInfo(attachment))
                 .Where(file => file != null)
                 .ToList();
@@ -176,9 +176,7 @@ namespace BugSplatDotNetStandard.Api
                         version,
                         md5,
                         s3Key,
-                        crashTypeId,
-                        defaultPostOptions,
-                        overridePostOptions
+                        crashTypeId
                     );
 
                     ThrowIfHttpRequestFailed(commitS3CrashResponse);
@@ -194,29 +192,38 @@ namespace BugSplatDotNetStandard.Api
             this.s3Client.Dispose();
         }
 
+        private List<FileInfo> CombineListsWithDuplicatesRemoved(
+            List<FileInfo> defaultList,
+            List<FileInfo> overrideList
+        )
+        {
+            return defaultList
+                .Concat(overrideList)
+                .GroupBy(file => file.FullName)
+                .Select(group => group.First())
+                .ToList();
+        }
+
         private async Task<HttpResponseMessage> CommitS3CrashUpload(
             string database,
             string application,
             string version,
             string md5,
             string s3Key,
-            int crashTypeId,
-            IBugSplatPostOptions defaultPostOptions,
-            IBugSplatPostOptions overridePostOptions
+            int crashTypeId
         )
         {
             var baseUrl = this.CreateBaseUrlFromDatabase(database);
             var route = $"{baseUrl}/api/commitS3CrashUpload";
-            var body = CreateMultiPartFormDataContent(
-                database,
-                application,
-                version,
-                defaultPostOptions,
-                overridePostOptions
-            );
-            body.Add(new StringContent($"{crashTypeId}"), "crashTypeId");
-            body.Add(new StringContent(s3Key), "s3Key");
-            body.Add(new StringContent(md5), "md5");
+            var body = new MultipartFormDataContent()
+            {
+                { new StringContent(database), "database" },
+                { new StringContent(application), "appName" },
+                { new StringContent(version), "appVersion" },
+                { new StringContent(crashTypeId.ToString()), "crashTypeId" },
+                { new StringContent(s3Key), "s3Key" },
+                { new StringContent(md5), "md5" }
+            };
 
             return await httpClient.PostAsync(route, body);
         }
@@ -224,74 +231,6 @@ namespace BugSplatDotNetStandard.Api
         private string CreateBaseUrlFromDatabase(string database)
         {
             return $"https://{database}.bugsplat.com";
-        }
-
-        private MultipartFormDataContent CreateMultiPartFormDataContent(
-            string database,
-            string application,
-            string version,
-            IBugSplatPostOptions defaultOptions,
-            IBugSplatPostOptions overrideOptions = null
-        )
-        {
-            var description = GetStringValueOrDefault(overrideOptions?.Description, defaultOptions.Description);
-            var email = GetStringValueOrDefault(overrideOptions?.Email, defaultOptions.Email);
-            var key = GetStringValueOrDefault(overrideOptions?.Key, defaultOptions.Key);
-            var notes = GetStringValueOrDefault(overrideOptions?.Notes, defaultOptions.Notes);
-            var user = GetStringValueOrDefault(overrideOptions?.User, defaultOptions.User);
-
-            var body = new MultipartFormDataContent
-            {
-                { new StringContent(database), "database" },
-                { new StringContent(application), "appName" },
-                { new StringContent(version), "appVersion" },
-                { new StringContent(description), "description" },
-                { new StringContent(email), "email" },
-                { new StringContent(key), "appKey" },
-                { new StringContent(notes), "notes" },
-                { new StringContent(user), "user" },
-            };
-
-            var formDataParams = overrideOptions?.FormDataParams ?? new List<IFormDataParam>();
-            formDataParams.AddRange(defaultOptions.FormDataParams);
-            foreach (var param in formDataParams)
-            {
-                if (!string.IsNullOrEmpty(param.FileName))
-                {
-                    body.Add(param.Content, param.Name, param.FileName);
-                    continue;
-                }
-
-                body.Add(param.Content, param.Name);
-            }
-
-            var attachments = new List<FileInfo>();
-            attachments.AddRange(defaultOptions.Attachments);
-            if (overrideOptions != null)
-            {
-                attachments.AddRange(overrideOptions.Attachments);
-            }
-
-            for (var i = 0; i < attachments.Count; i++)
-            {
-                byte[] bytes = null;
-                using (var fileStream = File.Open(attachments[i].FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                {
-                    using (var memoryStream = new MemoryStream())
-                    {
-                        fileStream.CopyTo(memoryStream);
-                        bytes = memoryStream.ToArray();
-                    }
-                }
-
-                if (bytes != null)
-                {
-                    var name = attachments[i].Name;
-                    body.Add(new ByteArrayContent(bytes), name, name);
-                }
-            }
-
-            return body;
         }
 
         private async Task<HttpResponseMessage> GetCrashUploadUrl(
@@ -305,7 +244,7 @@ namespace BugSplatDotNetStandard.Api
             var path = $"{baseUrl}/api/getCrashUploadUrl";
             var route = $"{path}?database={database}&appName={application}&appVersion={version}&crashPostSize={crashPostSize}";
 
-            
+
             return await httpClient.GetAsync(route);
         }
 

--- a/BugSplatDotNetStandard/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard/Api/CrashPostClient.cs
@@ -43,8 +43,8 @@ namespace BugSplatDotNetStandard.Api
         {
             overridePostOptions = overridePostOptions ?? new ExceptionPostOptions();
 
-            var files = overridePostOptions.Attachments
-                .Select(attachment => InMemoryFile.FromFileInfo(attachment))
+                .Select(attachment => TryCreateInMemoryFileFromFileInfo(attachment))
+                .Where(file => file != null)
                 .ToList();
             
             var additionalFormDataFiles = overridePostOptions.FormDataParams
@@ -143,8 +143,8 @@ namespace BugSplatDotNetStandard.Api
         {
             overridePostOptions = overridePostOptions ?? new MinidumpPostOptions();
 
-            var files = overridePostOptions.Attachments
-                .Select(attachment => InMemoryFile.FromFileInfo(attachment))
+                .Select(attachment => TryCreateInMemoryFileFromFileInfo(attachment))
+                .Where(file => file != null)
                 .ToList();
 
             files.Add(new InMemoryFile() { FileName = crashFileInfo.Name, Content = File.ReadAllBytes(crashFileInfo.FullName) });
@@ -330,6 +330,18 @@ namespace BugSplatDotNetStandard.Api
             catch (Exception ex)
             {
                 throw new Exception("Failed to parse crash upload url", ex);
+            }
+        }
+
+        private InMemoryFile TryCreateInMemoryFileFromFileInfo(FileInfo fileInfo)
+        {
+            try
+            {
+                return InMemoryFile.FromFileInfo(fileInfo);
+            }
+            catch
+            {
+                return null;
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Additionally, `Post` can be used to upload minidumps to BugSplat.
 await bugsplat.Post(new FileInfo("/path/to/minidump.dmp"));
 ```
 
-The default values for description, email, key and user can be overridden in the call to Post. Additional attachments can also be specified in the call to Post. Please note that the total size of the Post body and all attachments is limited to **20MB** by default.
+The default values for description, email, key and user can be overridden in the call to Post. Additional attachments can also be specified in the call to Post. If BugSplat can't read an attachment (e.g. the file is in use), it will be skipped. Please note that the total size of the Post body and all attachments is limited to **20MB** by default.
 
 ```cs
 var options = new ExceptionPostOptions()

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var options = new ExceptionPostOptions()
     User = "Fred",
     Key = "the key!"
 };
-options.AdditionalAttachments.Add(new FileInfo("/path/to/attachment2.txt"));
+options.Attachments.Add(new FileInfo("/path/to/attachment2.txt"));
 
 await bugsplat.Post(ex, options);
 ```


### PR DESCRIPTION
### Description

* Gracefully ignore adding attachments that can't be read.
* Fixed bug where original attachments were just forgotten about.
* Cleans up some bogus code that was unnecessarily reading files.

### TODO BG
- [x] Update docs and let customers know files aren't attached if we can't read them (aka locked)

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
