### PR TITLE
fix: don't lock attachment while reading

### DIFF
--- a/BugSplatDotNetStandard/Api/CrashDetailsClient.cs
+++ b/BugSplatDotNetStandard/Api/CrashDetailsClient.cs
@@ -1,0 +1,51 @@
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using static BugSplatDotNetStandard.Utils.ArgumentContracts;
+
+namespace BugSplatDotNetStandard.Api
+{
+    /// <summary>
+    /// Used to make requests to the BugSplat Versions API
+    /// </summary>
+    public class CrashDetailsClient
+    {
+        private IBugSplatApiClient bugsplatApiClient;
+
+        internal CrashDetailsClient(IBugSplatApiClient bugsplatApiClient)
+        {
+            ThrowIfArgumentIsNull(bugsplatApiClient, "bugsplatApiClient");
+
+            this.bugsplatApiClient = bugsplatApiClient;
+        }
+
+        /// <summary>
+        /// Create a CrashDetailsApiClient, consumer is responsible for authentication
+        /// </summary>
+        /// <param name="bugsplatApiClient">An authenticated instance of BugSplatApiClient that will be used for API requests</param>
+        public static CrashDetailsClient Create(IBugSplatApiClient bugsplatApiClient)
+        {
+            return new CrashDetailsClient(bugsplatApiClient);
+        }
+
+        /// <summary>
+        /// Get details of a crash from a BugSplat database by ID
+        /// </summary>
+        /// <param name="database">BugSplat database for which crash information will be retrieved</param>
+        /// <param name="id">Id of the crash to retrieve</param>
+        public async Task<HttpResponseMessage> GetCrashDetails(string database, int id)
+        {
+            ThrowIfArgumentIsNullOrEmpty(database, "database");
+            ThrowIfArgumentIsNullOrNegative(id, "id");
+
+            ThrowIfNotAuthenticated(bugsplatApiClient);
+
+            var response = await this.bugsplatApiClient.GetAsync($"/api/crash/details?database={database}&id={id}");
+
+            ThrowIfHttpRequestFailed(response);
+
+            return response;
+        }
+    }
+}

--- a/BugSplatDotNetStandard/Utils/ArgumentContracts.cs
+++ b/BugSplatDotNetStandard/Utils/ArgumentContracts.cs
@@ -13,6 +13,14 @@ namespace BugSplatDotNetStandard.Utils
             }
         }
 
+        internal static void ThrowIfArgumentIsNullOrNegative(int argument, string name)
+        {
+            if (argument <= 0)
+            {
+                throw new ArgumentException($"{name} cannot be null or less than zero!");
+            }
+        }
+
         internal static void ThrowIfArgumentIsNullOrEmpty(string argument, string name)
         {
             if (string.IsNullOrEmpty(argument))

--- a/BugSplatDotNetStandard/Utils/ZipUtils.cs
+++ b/BugSplatDotNetStandard/Utils/ZipUtils.cs
@@ -11,11 +11,16 @@ namespace BugSplatDotNetStandard.Utils
 
         public static InMemoryFile FromFileInfo(FileInfo fileInfo)
         {
-            return new InMemoryFile()
+            using (FileStream fileStream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (MemoryStream memoryStream = new MemoryStream())
             {
-                FileName = fileInfo.Name,
-                Content = File.ReadAllBytes(fileInfo.FullName)
-            };
+                fileStream.CopyTo(memoryStream);
+                return new InMemoryFile()
+                {
+                    FileName = fileInfo.Name,
+                    Content = memoryStream.ToArray()
+                };
+            }
         }
     }
 
@@ -28,7 +33,7 @@ namespace BugSplatDotNetStandard.Utils
         
     }
 
-    internal class ZipUtils: IZipUtils
+    internal class ZipUtils : IZipUtils
     {
         public byte[] CreateInMemoryZipFile(IEnumerable<InMemoryFile> files)
         {
@@ -52,12 +57,12 @@ namespace BugSplatDotNetStandard.Utils
 
             return zipBytes;
         }
-        
+
         public FileInfo CreateZipFile(string zipFileFullName, IEnumerable<FileInfo> files)
         {
             using (var zipFile = ZipFile.Open(zipFileFullName, ZipArchiveMode.Create))
             {
-                foreach(var file in files)
+                foreach (var file in files)
                 {
                     zipFile.CreateEntryFromFile(file.FullName, file.Name);
                 }


### PR DESCRIPTION
### Description

* Fixes attachment locking when copying to InMemoryFile
* Fixes missing crash metadata
* Adds CrashDetailsApiClient

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
