### PR TITLE
feat: add PostFeedback API for user feedback submission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish to NuGet
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Pack
+        run: dotnet pack BugSplatDotNetStandard/BugSplatDotNetStandard.csproj --configuration Release --no-build -p:Version=${{ steps.version.outputs.VERSION }} -o ./nupkg
+
+      - name: Decode DigiCert client certificate
+        run: echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > "${{ runner.temp }}/cert.p12"
+        shell: bash
+
+      - name: Setup DigiCert Software Trust Manager
+        uses: digicert/code-signing-software-trust-action@v1
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\cert.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: Sync certificate to Windows store
+        run: smctl windows certsync --keypair-alias=${{ secrets.SM_KEYPAIR_ALIAS }}
+        shell: cmd
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\cert.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: Sign NuGet package
+        run: nuget sign ./nupkg/*.nupkg -Timestamper http://timestamp.digicert.com -CertificateFingerprint ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} -HashAlgorithm SHA256 -Verbosity detailed -Overwrite
+        shell: cmd
+
+      - name: Verify signature
+        run: nuget verify -All ./nupkg/*.nupkg
+        shell: cmd
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Clean up
+        if: always()
+        run: rm -f "${{ runner.temp }}/cert.p12"
+        shell: bash

--- a/BugSplatDotNetStandard.Test/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard.Test/Api/CrashPostClient.cs
@@ -17,6 +17,7 @@ using System.Net;
 using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using BugSplatDotNetStandard.Utils;
 
 namespace Tests
 {

--- a/BugSplatDotNetStandard.Test/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard.Test/Api/CrashPostClient.cs
@@ -277,6 +277,179 @@ namespace Tests
             Assert.AreEqual(expectedContent, attachmentContent);
         }
 
+        [Test]
+        public async Task CrashPostClient_PostFeedback_ShouldReturn200()
+        {
+            var bugsplat = new BugSplat(database, application, version);
+            var getCrashUrl = "https://fake.url.com";
+            var mockHttp = CreateMockHttpClientForExceptionPost(getCrashUrl);
+            var httpClient = new HttpClient(mockHttp.Object);
+            var httpClientFactory = new FakeHttpClientFactory(httpClient);
+            var mockS3ClientFactory = FakeS3ClientFactory.CreateMockS3ClientFactory();
+
+            var sut = new CrashPostClient(httpClientFactory, mockS3ClientFactory);
+
+            var postResult = await sut.PostFeedback(
+                database,
+                application,
+                version,
+                "Test feedback title",
+                FeedbackPostOptions.Create(bugsplat)
+            );
+
+            Assert.AreEqual(HttpStatusCode.OK, postResult.StatusCode);
+        }
+
+        [Test]
+        public async Task CrashPostClient_PostFeedback_ShouldUseCrashTypeId36()
+        {
+            var bugsplat = new BugSplat(database, application, version);
+            var getCrashUrl = "https://fake.url.com";
+            HttpRequestMessage capturedCommitRequest = null;
+            var mockHttp = CreateMockHttpClientWithCapture(getCrashUrl, req => capturedCommitRequest = req);
+            var httpClient = new HttpClient(mockHttp.Object);
+            var httpClientFactory = new FakeHttpClientFactory(httpClient);
+            var mockS3ClientFactory = FakeS3ClientFactory.CreateMockS3ClientFactory();
+
+            var sut = new CrashPostClient(httpClientFactory, mockS3ClientFactory);
+
+            await sut.PostFeedback(
+                database,
+                application,
+                version,
+                "Test feedback title",
+                FeedbackPostOptions.Create(bugsplat)
+            );
+
+            Assert.IsNotNull(capturedCommitRequest);
+            var content = capturedCommitRequest.Content as MultipartFormDataContent;
+            Assert.IsNotNull(content);
+            var formData = await content.ReadAsStringAsync();
+            Assert.That(formData, Does.Contain("36"));
+        }
+
+        [Test]
+        public async Task CrashPostClient_PostFeedback_ShouldConstructFeedbackJsonWithEscaping()
+        {
+            var bugsplat = new BugSplat(database, application, version);
+            bugsplat.Description = "Line1\nLine2\twith \"quotes\"";
+            var getCrashUrl = "https://fake.url.com";
+            var mockHttp = CreateMockHttpClientForExceptionPost(getCrashUrl);
+            var httpClient = new HttpClient(mockHttp.Object);
+            var httpClientFactory = new FakeHttpClientFactory(httpClient);
+            var mockS3ClientFactory = FakeS3ClientFactory.CreateMockS3ClientFactory();
+
+            byte[] capturedBytes = null;
+            var mockTempFileFactory = new Mock<ITempFileFactory>();
+            var mockTempFile = new Mock<ITempFile>();
+            mockTempFile.Setup(t => t.File).Returns(new FileInfo("Files/minidump.dmp"));
+            mockTempFileFactory
+                .Setup(f => f.CreateFromBytes("feedback.json", It.IsAny<byte[]>()))
+                .Callback<string, byte[]>((name, bytes) => capturedBytes = bytes)
+                .Returns(mockTempFile.Object);
+            mockTempFileFactory
+                .Setup(f => f.CreateTempZip(It.IsAny<IEnumerable<FileInfo>>()))
+                .Returns(mockTempFile.Object);
+            mockTempFile
+                .Setup(t => t.CreateFileStream(It.IsAny<FileMode>(), It.IsAny<FileAccess>()))
+                .Returns(new MemoryStream(new byte[] { 0 }));
+
+            var sut = new CrashPostClient(httpClientFactory, mockS3ClientFactory);
+            sut.TempFileFactory = mockTempFileFactory.Object;
+
+            await sut.PostFeedback(
+                database,
+                application,
+                version,
+                "Title with \"quotes\"",
+                FeedbackPostOptions.Create(bugsplat)
+            );
+
+            Assert.IsNotNull(capturedBytes);
+            var feedbackJson = Encoding.UTF8.GetString(capturedBytes);
+            Assert.That(feedbackJson, Does.Contain("Title with \\\"quotes\\\""));
+            Assert.That(feedbackJson, Does.Contain("Line1\\nLine2\\twith \\\"quotes\\\""));
+        }
+
+        [Test]
+        public async Task CrashPostClient_PostFeedback_ShouldUseOverrideDescription()
+        {
+            var bugsplat = new BugSplat(database, application, version);
+            bugsplat.Description = "Default description";
+            var getCrashUrl = "https://fake.url.com";
+            var mockHttp = CreateMockHttpClientForExceptionPost(getCrashUrl);
+            var httpClient = new HttpClient(mockHttp.Object);
+            var httpClientFactory = new FakeHttpClientFactory(httpClient);
+            var mockS3ClientFactory = FakeS3ClientFactory.CreateMockS3ClientFactory();
+
+            byte[] capturedBytes = null;
+            var mockTempFileFactory = new Mock<ITempFileFactory>();
+            var mockTempFile = new Mock<ITempFile>();
+            mockTempFile.Setup(t => t.File).Returns(new FileInfo("Files/minidump.dmp"));
+            mockTempFileFactory
+                .Setup(f => f.CreateFromBytes("feedback.json", It.IsAny<byte[]>()))
+                .Callback<string, byte[]>((name, bytes) => capturedBytes = bytes)
+                .Returns(mockTempFile.Object);
+            mockTempFileFactory
+                .Setup(f => f.CreateTempZip(It.IsAny<IEnumerable<FileInfo>>()))
+                .Returns(mockTempFile.Object);
+            mockTempFile
+                .Setup(t => t.CreateFileStream(It.IsAny<FileMode>(), It.IsAny<FileAccess>()))
+                .Returns(new MemoryStream(new byte[] { 0 }));
+
+            var sut = new CrashPostClient(httpClientFactory, mockS3ClientFactory);
+            sut.TempFileFactory = mockTempFileFactory.Object;
+
+            var overrideOptions = new FeedbackPostOptions
+            {
+                Description = "Override description"
+            };
+
+            await sut.PostFeedback(
+                database,
+                application,
+                version,
+                "Test title",
+                FeedbackPostOptions.Create(bugsplat),
+                overrideOptions
+            );
+
+            Assert.IsNotNull(capturedBytes);
+            var feedbackJson = Encoding.UTF8.GetString(capturedBytes);
+            Assert.That(feedbackJson, Does.Contain("Override description"));
+            Assert.That(feedbackJson, Does.Not.Contain("Default description"));
+        }
+
+        private Mock<HttpMessageHandler> CreateMockHttpClientWithCapture(string crashUploadUrl, Action<HttpRequestMessage> captureCallback)
+        {
+            var getCrashUploadUrlResponse = new HttpResponseMessage();
+            getCrashUploadUrlResponse.StatusCode = HttpStatusCode.OK;
+            getCrashUploadUrlResponse.Content = new StringContent($"{{ \"url\": \"{crashUploadUrl}\" }}");
+
+            var commitCrashUploadUrlReponse = new HttpResponseMessage();
+            commitCrashUploadUrlReponse.StatusCode = HttpStatusCode.OK;
+
+            var callCount = 0;
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>()
+               )
+               .ReturnsAsync((HttpRequestMessage request, CancellationToken token) =>
+               {
+                   callCount++;
+                   if (callCount == 1)
+                       return getCrashUploadUrlResponse;
+                   captureCallback(request);
+                   return commitCrashUploadUrlReponse;
+               });
+
+            return handlerMock;
+        }
+
         private Mock<HttpMessageHandler> CreateMockHttpClientForExceptionPost(string crashUploadUrl)
         {
             var getCrashUploadUrlResponse = new HttpResponseMessage();

--- a/BugSplatDotNetStandard.Test/JsonObject.cs
+++ b/BugSplatDotNetStandard.Test/JsonObject.cs
@@ -96,5 +96,34 @@ namespace Tests
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        public void JsonSerializer_Serialize_ShouldEmitNullForNullValues()
+        {
+            var dictionary = new Dictionary<string, string>()
+            {
+                { "key", null }
+            };
+
+            var result = JsonSerializer.Serialize(dictionary);
+
+            Assert.AreEqual(@"{""key"":null}", result);
+        }
+
+        [Test]
+        public void JsonSerializer_EscapeJsonString_ShouldBePubliclyAccessible()
+        {
+            var result = JsonSerializer.EscapeJsonString("hello \"world\"");
+
+            Assert.AreEqual("hello \\\"world\\\"", result);
+        }
+
+        [Test]
+        public void JsonSerializer_EscapeJsonString_ShouldHandleEmoji()
+        {
+            var result = JsonSerializer.EscapeJsonString("😀");
+
+            Assert.AreEqual("\\uD83D\\uDE00", result);
+        }
     }
 }

--- a/BugSplatDotNetStandard.Test/SymbolUploader.cs
+++ b/BugSplatDotNetStandard.Test/SymbolUploader.cs
@@ -9,7 +9,8 @@ namespace Tests
     [TestFixture]
     public class SymbolUploaderTest
     {
-        private string database;        private string clientId;
+        private string database;
+        private string clientId;
         private string clientSecret;
 
         [OneTimeSetUp]

--- a/BugSplatDotNetStandard.Test/SymbolUploader.cs
+++ b/BugSplatDotNetStandard.Test/SymbolUploader.cs
@@ -9,10 +9,7 @@ namespace Tests
     [TestFixture]
     public class SymbolUploaderTest
     {
-        private string database;
-        private string email;
-        private string password;
-        private string clientId;
+        private string database;        private string clientId;
         private string clientSecret;
 
         [OneTimeSetUp]
@@ -20,26 +17,8 @@ namespace Tests
         {
             DotNetEnv.Env.Load();
             database = System.Environment.GetEnvironmentVariable("BUGSPLAT_DATABASE");
-            email = System.Environment.GetEnvironmentVariable("BUGSPLAT_EMAIL");
-            password = System.Environment.GetEnvironmentVariable("BUGSPLAT_PASSWORD");
             clientId = System.Environment.GetEnvironmentVariable("BUGSPLAT_CLIENT_ID");
             clientSecret = System.Environment.GetEnvironmentVariable("BUGSPLAT_CLIENT_SECRET");
-        }
-
-        [Test]
-        public void SymbolUploader_UploadSymbolFile_ShouldUploadSymbolFileToBugSplat()
-        {
-            var sut = SymbolUploader.CreateSymbolUploader(email, password);
-            var symbolFileInfo = new FileInfo("Files/myConsoleCrasher.exe");
-            var response = sut.UploadSymbolFile(
-                database,
-                "myConsoleCrasher",
-                "2022.5.2.0",
-                symbolFileInfo
-            ).Result;
-            var body = response.Content.ReadAsStringAsync().Result;
-
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Test]
@@ -68,7 +47,7 @@ namespace Tests
         [Test]
         public void SymbolUploader_UploadSymbolFileWithSignature_ShouldUploadSymbolFileToBugSplat()
         {
-            var sut = SymbolUploader.CreateSymbolUploader(email, password);
+            var sut = SymbolUploader.CreateOAuth2SymbolUploader(clientId, clientSecret);
             var symbolFileInfo = new FileInfo("Files/myConsoleCrasher.exe");
             var response = sut.UploadSymbolFile(
                 database,

--- a/BugSplatDotNetStandard/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard/Api/CrashPostClient.cs
@@ -101,7 +101,7 @@ namespace BugSplatDotNetStandard.Api
             FeedbackPostOptions overridePostOptions = null
         )
         {
-            var description = overridePostOptions?.Description ?? defaultPostOptions?.Description ?? string.Empty;
+            var description = GetStringValueOrDefault(overridePostOptions?.Description, defaultPostOptions?.Description);
             var feedbackJson = JsonSerializer.Serialize(new Dictionary<string, string>
             {
                 { "title", title },

--- a/BugSplatDotNetStandard/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard/Api/CrashPostClient.cs
@@ -102,7 +102,11 @@ namespace BugSplatDotNetStandard.Api
         )
         {
             var description = overridePostOptions?.Description ?? defaultPostOptions?.Description ?? string.Empty;
-            var feedbackJson = $"{{\"title\":{JsonEscape(title)},\"description\":{JsonEscape(description)}}}";
+            var feedbackJson = JsonSerializer.Serialize(new Dictionary<string, string>
+            {
+                { "title", title },
+                { "description", description }
+            });
             using (var feedbackTempFile = TempFileFactory.CreateFromBytes("feedback.json", Encoding.UTF8.GetBytes(feedbackJson)))
             {
                 return await PostCrashFile(
@@ -114,12 +118,6 @@ namespace BugSplatDotNetStandard.Api
                     overridePostOptions
                 );
             }
-        }
-
-        private static string JsonEscape(string value)
-        {
-            if (value == null) return "\"\"";
-            return "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t") + "\"";
         }
 
         public async Task<HttpResponseMessage> PostCrashFile(

--- a/BugSplatDotNetStandard/Api/CrashPostClient.cs
+++ b/BugSplatDotNetStandard/Api/CrashPostClient.cs
@@ -92,6 +92,36 @@ namespace BugSplatDotNetStandard.Api
             );
         }
 
+        public async Task<HttpResponseMessage> PostFeedback(
+            string database,
+            string application,
+            string version,
+            string title,
+            FeedbackPostOptions defaultPostOptions,
+            FeedbackPostOptions overridePostOptions = null
+        )
+        {
+            var description = overridePostOptions?.Description ?? defaultPostOptions?.Description ?? string.Empty;
+            var feedbackJson = $"{{\"title\":{JsonEscape(title)},\"description\":{JsonEscape(description)}}}";
+            using (var feedbackTempFile = TempFileFactory.CreateFromBytes("feedback.json", Encoding.UTF8.GetBytes(feedbackJson)))
+            {
+                return await PostCrashFile(
+                    database,
+                    application,
+                    version,
+                    feedbackTempFile.File,
+                    defaultPostOptions,
+                    overridePostOptions
+                );
+            }
+        }
+
+        private static string JsonEscape(string value)
+        {
+            if (value == null) return "\"\"";
+            return "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t") + "\"";
+        }
+
         public async Task<HttpResponseMessage> PostCrashFile(
             string database,
             string application,

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -299,10 +299,7 @@ namespace BugSplatDotNetStandard
                 using (var crashPostClient = new CrashPostClient(HttpClientFactory.Default, S3ClientFactory.Default))
                 {
                     var defaultOptions = FeedbackPostOptions.Create(this);
-                    if (!string.IsNullOrEmpty(description))
-                    {
-                        defaultOptions.Description = description;
-                    }
+                    defaultOptions.Description = description;
                     return await crashPostClient.PostFeedback(
                         Database,
                         Application,

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -278,5 +278,46 @@ namespace BugSplatDotNetStandard
                 return null;
             }
         }
+
+        /// <summary>
+        /// Post user feedback to BugSplat
+        /// </summary>
+        /// <param name="title">The feedback title, used as the stack key for grouping</param>
+        /// <param name="description">Additional feedback context</param>
+        /// <param name="options">Optional parameters that will override the defaults if provided</param>
+        /// <returns>HttpResponseMessage if successful, null if arguments are invalid or if an error occurs</returns>
+        public async Task<HttpResponseMessage> PostFeedback(string title, string description = "", FeedbackPostOptions options = null)
+        {
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                Console.Error.WriteLine("Error: title cannot be null, empty, or only white space when posting feedback to BugSplat");
+                return null;
+            }
+
+            try
+            {
+                using (var crashPostClient = new CrashPostClient(HttpClientFactory.Default, S3ClientFactory.Default))
+                {
+                    var defaultOptions = FeedbackPostOptions.Create(this);
+                    if (!string.IsNullOrEmpty(description))
+                    {
+                        defaultOptions.Description = description;
+                    }
+                    return await crashPostClient.PostFeedback(
+                        Database,
+                        Application,
+                        Version,
+                        title,
+                        defaultOptions,
+                        options
+                    );
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error posting feedback to BugSplat: {ex.Message}");
+                return null;
+            }
+        }
     }
 }

--- a/BugSplatDotNetStandard/BugSplatPostOptions.cs
+++ b/BugSplatDotNetStandard/BugSplatPostOptions.cs
@@ -73,7 +73,8 @@ namespace BugSplatDotNetStandard
 
     public class FeedbackPostOptions : BugSplatPostOptions
     {
-        public override int CrashTypeId { get => 36; }
+        private const int FeedbackCrashTypeId = 36;
+        public override int CrashTypeId { get => FeedbackCrashTypeId; }
         public static FeedbackPostOptions Create(IBugSplatPostOptions options)
         {
             return new FeedbackPostOptions

--- a/BugSplatDotNetStandard/BugSplatPostOptions.cs
+++ b/BugSplatDotNetStandard/BugSplatPostOptions.cs
@@ -71,6 +71,26 @@ namespace BugSplatDotNetStandard
         }
     }
 
+    public class FeedbackPostOptions : BugSplatPostOptions
+    {
+        public override int CrashTypeId { get => 36; }
+        public static FeedbackPostOptions Create(IBugSplatPostOptions options)
+        {
+            return new FeedbackPostOptions
+            {
+                Attachments = options.Attachments,
+                Attributes = options.Attributes,
+                FormDataParams = options.FormDataParams,
+                Description = options.Description,
+                Email = options.Email,
+                Key = options.Key,
+                IpAddress = options.IpAddress,
+                Notes = options.Notes,
+                User = options.User
+            };
+        }
+    }
+
     public class BugSplatPostOptions : IBugSplatPostOptions, IHasCrashTypeId
     {
         public List<FileInfo> Attachments { get; set; } = new List<FileInfo>();

--- a/BugSplatDotNetStandard/Http/JsonObject.cs
+++ b/BugSplatDotNetStandard/Http/JsonObject.cs
@@ -60,7 +60,13 @@ namespace BugSplatDotNetStandard.Http
                 if (!isFirst)
                     sb.Append(",");
 
-                sb.Append($"\"{EscapeJsonString(kvp.Key)}\":\"{EscapeJsonString(kvp.Value)}\"");
+                sb.Append($"\"{EscapeJsonString(kvp.Key)}\":");
+
+                if (kvp.Value == null)
+                    sb.Append("null");
+                else
+                    sb.Append($"\"{EscapeJsonString(kvp.Value)}\"");
+
                 isFirst = false;
             }
 
@@ -68,12 +74,12 @@ namespace BugSplatDotNetStandard.Http
             return sb.ToString();
         }
 
-        private static string EscapeJsonString(string str)
+        public static string EscapeJsonString(string str)
         {
             if (string.IsNullOrEmpty(str))
                 return string.Empty;
 
-            var sb = new StringBuilder();
+            var sb = new StringBuilder(str.Length + 16);
             foreach (char c in str)
             {
                 switch (c)
@@ -86,12 +92,17 @@ namespace BugSplatDotNetStandard.Http
                     case '\r': sb.Append("\\r"); break;
                     case '\t': sb.Append("\\t"); break;
                     default:
-                        // Check if the character is outside the range of printable ASCII characters
-                        // ASCII 32 is space, and 127 is DEL. Characters outside this range need to be escaped.
                         if (c < 32 || c > 127)
+                        {
+                            // Characters above U+FFFF (e.g. emoji) are represented as surrogate pairs
+                            // in C# strings. Each half is emitted as a separate \uXXXX escape, which is
+                            // valid JSON per RFC 8259.
                             sb.Append($"\\u{(int)c:X4}");
+                        }
                         else
+                        {
                             sb.Append(c);
+                        }
                         break;
                 }
             }

--- a/BugSplatDotNetStandard/SymbolUploader.cs
+++ b/BugSplatDotNetStandard/SymbolUploader.cs
@@ -39,18 +39,6 @@ namespace BugSplatDotNetStandard
         }
 
         /// <summary>
-        /// Create a BugSplat SymbolUploader via an BugSplat email/password pair.
-        /// </summary>
-        /// <param name="email">BugSplat account email</param>
-        /// <param name="password">BugSplat account password</param>
-        public static SymbolUploader CreateSymbolUploader(string email, string password)
-        {
-            return new SymbolUploader(
-                BugSplatApiClient.Create(email, password)
-            );
-        }
-
-        /// <summary>
         /// Upload a symbol file to BugSplat
         /// </summary>
         /// <param name="database">BugSplat database to upload symbols too</param>


### PR DESCRIPTION
## Summary
- Adds `FeedbackPostOptions` class with `CrashTypeId = 36` (User.Feedback)
- Adds `PostFeedback` method to `CrashPostClient` that creates `feedback.json` with `{title, description}` and delegates to existing presigned URL upload flow
- Adds public `PostFeedback(string title, string description, FeedbackPostOptions options)` to `BugSplat` class

## Test plan
- [x] Call `PostFeedback("Test feedback title", "Test description")` with test database/app/version
- [x] Verify the report appears in BugSplat dashboard with crash type "User.Feedback"
- [x] Verify `feedback.json` is accessible in the crash details
- [x] Verify user, email, description, attributes flow through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)